### PR TITLE
[fix] set collection_id correctly if _embedding_length is configured

### DIFF
--- a/langchain_mariadb/vectorstores.py
+++ b/langchain_mariadb/vectorstores.py
@@ -1342,7 +1342,10 @@ class MariaDBStore(VectorStore):
         if self.lazy_init and not self._embedding_length:
             self._embedding_length = len(embedding)
             self._init_vectorstore()
-
+        else:
+            collection_id = self._check_if_collection_exists()
+            if collection_id is not None:
+                self._collection_id = collection_id
         return self.__inner_query_collection(embedding=embedding, k=k, query_=query)
 
     def __query_with_score_collection(


### PR DESCRIPTION

## Bug Explanation

**Root Cause:**

When `lazy_init=True` and `embedding_length` is provided (e.g., `embedding_length=3072`), the collection initialization is skipped, leaving `self._collection_id` as `None`.

**Flow:**

1. In `__init__` (line 390-394): With `lazy_init=True`, `_init_vectorstore()` is not called, so `_collection_id` stays `None`.

2. In `__query_collection` (line 1342): The condition is:
   ```python
   if self.lazy_init and not self._embedding_length:
   ```
   If `embedding_length` is provided, `not self._embedding_length` is `False`, so `_init_vectorstore()` is never called.

3. Result: `_collection_id` remains `None`, and `__inner_query_collection` (line 1399) executes with `self._collection_id = None`, causing the query to return no results.

**Fix:**

Check if the collection needs initialization regardless of whether `embedding_length` is set. For example:
```python
      if self.lazy_init and not self._embedding_length:
          self._embedding_length = len(embedding)
          self._init_vectorstore()
      else:
          collection_id = self._check_if_collection_exists()
          if collection_id is not None:
              self._collection_id = collection_id
```

This ensures the collection is initialized when `lazy_init=True` and `_collection_id` is `None`, even if `embedding_length` was provided upfront.